### PR TITLE
Fix Bug in LibXC CI Install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Libxc Python Library
       shell: bash
       run: |
+        eval "$(conda shell.bash hook)" && conda activate test
         cd ~
         wget --content-disposition  http://www.tddft.org/programs/libxc/down.php?file=5.0.0/libxc-5.0.0.tar.gz
         tar xf libxc-5.0.0.tar.gz


### PR DESCRIPTION
The CI install of `pylibxc` is not done using the Conda install of Python, which results in the package being unavailable to pytest.  This PR installs `pylibxc` within the Conda environment, allowing the pytest tests to run successfully.